### PR TITLE
Add onclick support for confirmation button

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Use the component's HTML tag wherever you want:
     icon=""
     confirming-text=""
     confirming-url=""
+    confirming-callback=""
     dismissive-text=""
 >
 </myuw-banner>
@@ -35,7 +36,8 @@ Use the component's HTML tag wherever you want:
 - **message:** Sets the message to display in the banner
 - **icon:** Sets an icon to go with the message (optional)
 - **confirming-text:** Sets the text for the rightmost button (take action/confirmation)
-- **confirming-url:** Sets the url to go to when the confirming button is clicked
+- **confirming-url:** Sets the url to go to when the confirming button is clicked (optional)
+- **confirming-callback:** Sets the onclick event for the button (optional). Must be used if no `confirming-url` is set (and vice versa).
 - **dismissive-text:** Sets the text for the leftmost button (skip action/dismiss banner)
 
 ### Styling the banner

--- a/index.html
+++ b/index.html
@@ -39,7 +39,8 @@
           message="This is a test message for the MyUW Banner web component"
           icon="favorite"
           confirming-text="Take action"
-          confirming-url="#"
+          confirming-url=""
+          confirming-callback="testCallback()"
           dismissive-text="Skip for now">
         </myuw-banner>
         <div class="demo__container">
@@ -52,6 +53,8 @@
     </body>
 
     <script>
-      
+      function testCallback() {
+        console.log('callback works');
+      }
     </script>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-banner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-banner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "module": "dist/myuw-banner.min.mjs",
   "browser": "dist/myuw-banner.min.js",

--- a/src/myuw-banner.html
+++ b/src/myuw-banner.html
@@ -141,6 +141,6 @@
   </div>
   <div id="myuw-banner__actions">
     <button id="myuw-banner__actions--dismissive"></button>
-    <a id="myuw-banner__actions--confirming" href="" target="_blank"></button>
+    <a id="myuw-banner__actions--confirming"></a>
   </div>
 </div>

--- a/src/myuw-banner.js
+++ b/src/myuw-banner.js
@@ -26,6 +26,7 @@ class MyUWBanner extends HTMLElement {
       'icon',
       'confirming-text',
       'confirming-url',
+      'confirming-callback',
       'dismissive-text'
     ];
   }
@@ -37,7 +38,9 @@ class MyUWBanner extends HTMLElement {
     // Update the attribute internally
     this[name] = newValue;
     // Update the component
-    this.updateComponent();
+    if (this.$messageText && this.$illustration && this.$confirmingButton && this.$dismissiveButton) {
+      this.updateComponent();
+    }
   }
 
   /**
@@ -50,6 +53,7 @@ class MyUWBanner extends HTMLElement {
     this['icon']                  = this.getAttribute('icon') || '';
     this['confirming-text']       = this.getAttribute('confirming-text') || '';
     this['confirming-url']        = this.getAttribute('confirming-url') || '';
+    this['confirming-callback']   = this.getAttribute('confirming-callback') || '';
     this['dismissive-text']       = this.getAttribute('dismissive-text') || '';
     
     this.$banner = this.shadowRoot.getElementById('myuw-banner');
@@ -95,7 +99,13 @@ class MyUWBanner extends HTMLElement {
 
     this.$confirmingButton.innerText = this['confirming-text'];
     this.$confirmingButton.setAttribute('aria-label', this['confirming-text']);
-    this.$confirmingButton.setAttribute('href', this['confirming-url']);
+
+    if (this['confirming-url'].length > 0) {
+      this.$confirmingButton.setAttribute('href', this['confirming-url']);
+      this.$confirmingButton.setAttribute('target', '_blank');
+    } else if (this['confirming-callback'].length > 0) {
+      this.$confirmingButton.setAttribute('onclick', this['confirming-callback']);
+    }
 
     // Show  banner
     this.$banner.classList.add('open');


### PR DESCRIPTION
**In this PR:**
- New attribute `confirming-callback` to be set when adopter prefers to fire an event rather than go to a URL
- Either `confirming-callback` or `confirming-url` must be used
- Component will prefer `confirming-url` if both are present
- Fixed component trying to update before its DOM elements are setup