### PR TITLE
goofy change to repurpose dismiss button for hard-coded Learn more link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # myuw-banner versions
 
+## 2.0.0 - 2021-04-12
+
+- BREAKING, goofy change: replaces the dismiss button with a hard-coded
+  "Learn more" link supporting the banner message about availability of the
+  2020 WRS ETF Statement of Benefits.
+
 ## 1.2.4
 
 ### Updated

--- a/src/myuw-banner.html
+++ b/src/myuw-banner.html
@@ -154,7 +154,10 @@
     <span id="myuw-banner__text"></span>
   </div>
   <div id="myuw-banner__actions">
-    <button aria-live="polite" id="myuw-banner__actions--dismissive" ></button>
+    <a aria-live="polite" id="myuw-banner__actions--dismissive"
+      aria-label="Learn more about the 2020 WRS ETF Statement of Benefits"
+      target="_blank" href="https://uwservice.wisconsin.edu/news/post/628">
+      Learn more</a>
     <a aria-live="polite" id="myuw-banner__actions--confirming"></a>
   </div>
 </div>

--- a/src/myuw-banner.js
+++ b/src/myuw-banner.js
@@ -65,8 +65,10 @@ class MyUWBanner extends HTMLElement {
 
     // Listen for open events and set positioning
     this.$dismissiveButton.addEventListener('click', () => {
-      // Dismiss the banner
-      this.$banner.classList.remove('open');
+      // Do not dismiss the banner, since we are abusing the dismissive button
+      // not to dismiss the banner message, but to offer a learn more link.
+      // A user might learn more and then, having learned more, wish to click
+      // the action button.
     });
 
     this.$confirmingButton.addEventListener('click', () => {
@@ -92,10 +94,6 @@ class MyUWBanner extends HTMLElement {
     } else {
       this.$illustration.style.display = 'none';
     }
-    
-    // Set up buttons
-    this.$dismissiveButton.innerText = this['dismissive-text'];
-    this.$dismissiveButton.setAttribute('aria-label', this['dismissive-text']);
 
     this.$confirmingButton.innerText = this['confirming-text'];
     this.$confirmingButton.setAttribute('aria-label', this['confirming-text']);


### PR DESCRIPTION
Hard code a "Learn more" link for the banner message announcing availability of the issued-in-2021 about-2020 WRS ETF SoB. This is to deliver this Learn more link feature for this specific message in time for the message launch. Thereafter, the intention is to implement the "Learn more" link feature right.

![Screen capture showing that the Skip for now button has been re-purposed as a Learn more link](https://user-images.githubusercontent.com/952283/114486880-3b962600-9bd4-11eb-9a3a-00a5111b96db.png)
