### PR TITLE
Implement learn more link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # myuw-banner versions
 
+## 3.0.0 - 2021-04-22
+
+BREAKING CHANGES:
+
++ Removed dismiss feature.
+  Dismiss had not been, in practice, implemented in a way that persisted anyway.
++ Added learn more link feature.
++ Removed hard-coded learn more link specific to 2020 WRS ETF SoB.
++ Re-named attributes.
+
 ## 2.0.0 - 2021-04-12
 
 - BREAKING, goofy change: replaces the dismiss button with a hard-coded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,63 +12,52 @@ BREAKING CHANGES:
 
 ## 2.0.0 - 2021-04-12
 
-- BREAKING, goofy change: replaces the dismiss button with a hard-coded
++ BREAKING, goofy change: replaces the dismiss button with a hard-coded
   "Learn more" link supporting the banner message about availability of the
   2020 WRS ETF Statement of Benefits.
 
 ## 1.2.4
 
-### Updated
-- Remove max-height property of the banner to prevent content from not fitting in the view
-- Update padding around the content
++ Removed max-height property of the banner
+  to ensure content fits in the view
++ Updated padding around the content
 
 ## 1.2.3
 
-### Updated
-- Update max-width of the banner to avoid the content being too distant from the action buttons on screens above 1400px
++ Updated max-width of the banner
+  to avoid the content being too distant from the action buttons
+  on screens above 1400px
 
 ## 1.2.2
 
-### Added
-- Add style to make main CTA more prominent
++ Add style to make main call-to-action more prominent
 
 ## 1.2.1
 
-### Added
-- Aria implementation for minor accessibility improvements
++ ARIA implementation for minor accessibility improvements
 
 ## 1.2.0
 
-### Added
-- Delivery pipeline
-- Contributing guidelines
+(No functional changes.)
 
 ## 1.1.1
 
-### Fixed
-- Adjusted vertical alignment of elements to be more attractive on many screen sizes.
++ Adjusted vertical alignment of elements to be more attractive
+  on many screen sizes.
 
 ## 1.1.0
 
-### Added
-- New attribute `confirming-callback` sets the `onclick` attribute for the confirmation button. If both `confirming-callback` and `confirming-url` are present, the component will prefer `confirming-url`.
++ New attribute `confirming-callback`
+  sets the `onclick` attribute for the confirmation button.
+  If both `confirming-callback` and `confirming-url` are present,
+  the component will prefer `confirming-url`.
 
 ## 1.0.2
 
-### Fixed
-- Button font-size to `em` for consistency with banner font
-- Adjust layout on different screen sizes
-- Banner no longer displays on large screens when it should be hidden
++ Button font-size to `em` for consistency with banner font
++ Adjust layout on different screen sizes
++ Banner no longer displays on large screens when it should be hidden
 
 ## 1.0.1
 
-### Added
-- Banner closes when buttons are clicked (animated slide)
-
-## 1.0.0
-
-First version available for download
-
-## 0.0.1
-
-First commit of banner component.
++ Banner closes when buttons are clicked (animated slide)

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ Include the component as follows:
 <myuw-banner
   message="MyUW"
   icon=""
-  confirming-text=""
-  confirming-url=""
-  confirming-callback=""
-  dismissive-text=""
+  action-label=""
+  action-aria-label=""
+  action-url=""
+  learn-more-aria-label=""
+  learn-more-url=""
 ></myuw-banner>
 ```
 
@@ -29,10 +30,25 @@ _Note:_ The evergreen "latest" version can be used for convenience, but in produ
 
 - **message:** Sets the message to display in the banner
 - **icon:** Sets an icon to go with the message (optional)
-- **confirming-text:** Sets the text for the rightmost button (take action/confirmation)
-- **confirming-url:** Sets the url to go to when the confirming button is clicked (optional)
-- **confirming-callback:** Sets the onclick event for the button (optional). Must be used if no `confirming-url` is set (and vice versa).
-- **dismissive-text:** Sets the text for the leftmost button (skip action/dismiss banner)
+- **action-label:** Sets the text for the rightmost button (take action/confirmation)
+- **action-aria-label:** Sets the aria label for the action button.
+  Whereas a label like "Sign up" might make little sense out of context,
+  an ARIA label like "Sign up for a vaccination appointment"
+  clarifies what one is signing up for.
+- **action-url:** Sets the url to go to when the confirming button is clicked
+  (required)
+- **learn-more-aria-label:** Sets the aria-label for the secondary button.
+  This addresses the usability problem that
+  for a typical user a label like "Learn more" might be sufficient
+  because the context is visually apparent from the placement of the button,
+  but for a user consuming the links out of context
+  (e.g., jumping between links in a screen reader browser),
+  a label like "Learn more" prompts the question "Learn more *about what???*".
+  This ARIA label is a chance to make it apparent what it is one would learn more about.
+  A reasonable value for this might be "Learn more about making a COVID-19 vaccination appointment."
+  (optional; required if learn-more-url is set)
+- **learn-more-url:** Sets the href for the secondary button.
+  (optional: if not set, button does not appear)
 
 ### Styling the banner
 

--- a/index.html
+++ b/index.html
@@ -32,10 +32,11 @@
 <myuw-banner
   message="This is a test message for the MyUW Banner web component"
   icon="favorite"
-  confirming-text="Take action"
-  confirming-url=""
-  confirming-callback="console.log('callback works')"
-  dismissive-text="Skip for now"
+  action-label="Take action"
+  action-aria-label="Take action on the test banner message"
+  action-url="https://www.example.edu/an-example-action-url"
+  learn-more-aria-label="Learn more about this test banner message"
+  learn-more-url="https://www.example.edu/a-learn-more-url"
 ></myuw-banner>
 
 <div class="demo__container">

--- a/src/myuw-banner.html
+++ b/src/myuw-banner.html
@@ -104,7 +104,7 @@
     background: var(--myuw-button-transparency, rgba(0,0,0,0.12));
   }
 
-  #myuw-banner__actions--confirming {
+  #myuw-banner__actions--action {
     margin-left: 8px;
   }
 
@@ -154,10 +154,9 @@
     <span id="myuw-banner__text"></span>
   </div>
   <div id="myuw-banner__actions">
-    <a aria-live="polite" id="myuw-banner__actions--dismissive"
-      aria-label="Learn more about the 2020 WRS ETF Statement of Benefits"
-      target="_blank" href="https://uwservice.wisconsin.edu/news/post/628">
+    <a aria-live="polite" id="myuw-banner__actions--learn-more"
+      target="_blank">
       Learn more</a>
-    <a aria-live="polite" id="myuw-banner__actions--confirming"></a>
+    <a aria-live="polite" id="myuw-banner__actions--action"></a>
   </div>
 </div>

--- a/src/myuw-banner.js
+++ b/src/myuw-banner.js
@@ -24,10 +24,12 @@ class MyUWBanner extends HTMLElement {
     return [
       'message',
       'icon',
-      'confirming-text',
-      'confirming-url',
-      'confirming-callback',
-      'dismissive-text'
+      'action-label',
+      'action-aria-label',
+      'action-url',
+      'action-callback',
+      'learn-more-aria-label',
+      'learn-more-url'
     ];
   }
 
@@ -38,7 +40,7 @@ class MyUWBanner extends HTMLElement {
     // Update the attribute internally
     this[name] = newValue;
     // Update the component
-    if (this.$messageText && this.$illustration && this.$confirmingButton && this.$dismissiveButton) {
+    if (this.$messageText && this.$illustration && this.$actionButton) {
       this.updateComponent();
     }
   }
@@ -51,28 +53,24 @@ class MyUWBanner extends HTMLElement {
     // Get all attributes
     this['message']               = this.getAttribute('message') || '';
     this['icon']                  = this.getAttribute('icon') || '';
-    this['confirming-text']       = this.getAttribute('confirming-text') || '';
-    this['confirming-url']        = this.getAttribute('confirming-url') || '';
-    this['confirming-callback']   = this.getAttribute('confirming-callback') || '';
-    this['dismissive-text']       = this.getAttribute('dismissive-text') || '';
-    
+    this['action-label']       = this.getAttribute('action-label') || '';
+    this['action-aria-label']       = this.getAttribute('action-aria-label') || '';
+    this['action-url']        = this.getAttribute('action-url') || '';
+    this['action-callback']   = this.getAttribute('action-callback') || '';
+    this['learn-more-aria-label']       = this.getAttribute('learn-more-aria-label') || '';
+    this['learn-more-url']       = this.getAttribute('learn-more-url') || '';
+
     this.$banner = this.shadowRoot.getElementById('myuw-banner');
     this.$message = this.shadowRoot.getElementById('myuw-banner__message');
     this.$messageText = this.shadowRoot.getElementById('myuw-banner__text');
     this.$illustration = this.shadowRoot.getElementById('myuw-banner__illustration');
-    this.$dismissiveButton = this.shadowRoot.getElementById('myuw-banner__actions--dismissive');
-    this.$confirmingButton = this.shadowRoot.getElementById('myuw-banner__actions--confirming');
+    this.$learnMoreButton = this.shadowRoot.getElementById('myuw-banner__actions--learn-more');
+    this.$actionButton = this.shadowRoot.getElementById('myuw-banner__actions--action');
 
     // Listen for open events and set positioning
-    this.$dismissiveButton.addEventListener('click', () => {
-      // Do not dismiss the banner, since we are abusing the dismissive button
-      // not to dismiss the banner message, but to offer a learn more link.
-      // A user might learn more and then, having learned more, wish to click
-      // the action button.
-    });
 
-    this.$confirmingButton.addEventListener('click', () => {
-      // Dismiss the banner
+    this.$actionButton.addEventListener('click', () => {
+      // Dismiss the banner upon taking action
       this.$banner.classList.remove('open');
     });
 
@@ -91,21 +89,29 @@ class MyUWBanner extends HTMLElement {
     // Set icon
     if (this['icon'].length > 0) {
       this.$illustration.innerHTML = this['icon'];
+      this.$illustration.style.display = '';
     } else {
       this.$illustration.style.display = 'none';
     }
 
-    this.$confirmingButton.innerText = this['confirming-text'];
-    this.$confirmingButton.setAttribute('aria-label', this['confirming-text']);
+    this.$actionButton.innerText = this['action-label'];
+    this.$actionButton.setAttribute('aria-label', this['action-aria-label']);
 
-    if (this['confirming-url'].length > 0) {
-      this.$confirmingButton.setAttribute('href', this['confirming-url']);
-      this.$confirmingButton.setAttribute('target', '_blank');
-    } else if (this['confirming-callback'].length > 0) {
-      this.$confirmingButton.setAttribute('onclick', this['confirming-callback']);
+    if (this['action-url'].length > 0) {
+      this.$actionButton.setAttribute('href', this['action-url']);
+      this.$actionButton.setAttribute('target', '_blank');
     }
 
-    // Show  banner
+    if (this['learn-more-url'].length > 0) {
+      this.$learnMoreButton.setAttribute('href', this['learn-more-url']);
+      this.$learnMoreButton.setAttribute('target', '_blank');
+      this.$learnMoreButton.setAttribute('aria-label', this['learn-more-aria-label']);
+      this.$learnMoreButton.style.display = '';
+    } else {
+      this.$learnMoreButton.style.display = 'none';
+    }
+
+    // Show banner
     this.$banner.classList.add('open');
   }
 }


### PR DESCRIPTION
2.0.0 included a hard coded learn more link stuffed in to meet an immediate need.

This implements the learn more link "the right way" for a 3.0.0 release. With the major, breaking version change, also takes the opportunity to remove the unused JavaScript callback feature, to add accessibility support with aria labels, and to rename attributes for clarity. It's a major, breaking version change.

[MYUWADMIN-1483](https://jira.doit.wisc.edu/jira/browse/MYUWADMIN-1483)